### PR TITLE
fix(docker-compse): auto restart mongo-express

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       - ./MongoDB:/data/db
 
   mongo-express:
+    restart:
+      always
+    depends_on:
+      - mongo
+    links:
+      - mongo
     image: mongo-express:1.0.0-alpha.4
 
   web:


### PR DESCRIPTION
Due to the dependency of mongo and mongo-express,
we have to start mongo-express after mongo.
So I auto restart mongo-express to wait mongo completely start