### PR TITLE
fix: remove unused `vue-dist` volume in caddy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-docker-compose down
-docker volume rm -f normal-oj_vue-dist
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml build --no-cache
+docker-compose down
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,6 @@ services:
     volumes:
       - ./.config/Caddyfile.prod:/etc/caddy/Caddyfile
       - ./.caddy:/data
-      - vue-dist:/vue/dist
     env_file:
       - .secret/caddy.env
   mongo:


### PR DESCRIPTION
currently we host frontend on cloudflare. it's no deployed on production server.