### PR TITLE
build(caddy): support wildcard CORS

### DIFF
--- a/.config/Caddyfile.prod
+++ b/.config/Caddyfile.prod
@@ -1,6 +1,6 @@
 (cors) {
-    @origin{args.0} header Origin {args.0}
-    header @origin{args.0} Access-Control-Allow-Origin "{args.0}"
+    @origin{args.0} header_regexp origin Origin {args.0}
+    header @origin{args.0} Access-Control-Allow-Origin {re.origin.0}
 }
 
 {$SITE_ADDRESS} {
@@ -9,8 +9,9 @@
     header Access-Control-Allow-Methods "OPTIONS, GET, POST, PUT, DELETE, HEAD"
     header Access-Control-Allow-Credentials true
     # TODO: use env var to control allow origin, or move these to flask
-    import cors https://www.noj.tw
-    import cors https://v2.noj.tw
+    import cors "https://([^.]+\.)?nfe\.pages\.dev"
+    import cors "https://([^.]+\.)?noj\.tw"
+    import cors "http://localhost(:\d+)?"
 
     metrics /metrics
     reverse_proxy web:8080


### PR DESCRIPTION
CORS for:
- `<subdomain>.nfe.pages.dev`, `nfe.pages.dev`
- `<subdomain>.noj.tw`, `noj.tw`
- `localhost:<port>`, `localhost`

resolve #24 