### PR TITLE
fix: chg logs dir, this is uncommitted chg on prod server

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,8 +31,6 @@ services:
       - .secret/sandbox.env
     volumes:
       - ./Sandbox/submissions:/app/submissions
-      - ./Sandbox/access.log:/app/access.log
-      - ./Sandbox/error.log:/app/error.log
-      - ./Sandbox/sandbox.log:/app/sandbox.log
+      - ./Sandbox/logs:/app/logs
   redis:
     restart: unless-stopped


### PR DESCRIPTION
Fix #56

This change of logs directory is based on the source code (and confirmed by Bogay in #56):
- https://github.com/Normal-OJ/Sandbox/blob/b9583388a0b8ff6bbdd85222d12ed212c4ec63f3/gunicorn.conf.py#L6
- https://github.com/Normal-OJ/Sandbox/blob/b9583388a0b8ff6bbdd85222d12ed212c4ec63f3/app.py#L15

This should be moved to `docker-compose.yml` right? but out of scope, let's create another issue and PR afterward